### PR TITLE
Resolve an import error in pip installation using `py_modules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ QIWIS (**Q**u**I**qcl **W**idget **I**ntegration **S**oftware) is a framework fo
 ## How to download and install
 One of the below:
 - Using released version (_recommended_)
-1. `pip install -e git+https://github.com/snu-quiqcl/qiwis.git@v2.0.1#egg=qiwis`  
+1. `pip install git+https://github.com/snu-quiqcl/qiwis.git@v2.0.2`  
 For details, refer to [VCS Support](https://pip.pypa.io/en/stable/topics/vcs-support/).
 
 - Using git directly
@@ -20,6 +20,8 @@ For details, refer to [VCS Support](https://pip.pypa.io/en/stable/topics/vcs-sup
 2. In the repository, `pip install -e .`
 
 ## How to use
-In the repository, just do like as below:
+In the repository, just do like as below:  
+`python -m qiwis (-s ${setup_file))`
 
-`python -m qiwis (-s ${setup_file))`.
+If you installed `qiwis`, you can use it everywhere as below:  
+`qiwis (-s ${setup_file))`

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ QIWIS (**Q**u**I**qcl **W**idget **I**ntegration **S**oftware) is a framework fo
 ## How to download and install
 One of the below:
 - Using released version (_recommended_)
-1. `pip install -e git+https://github.com/snu-quiqcl/qiwis.git@v2.0.1#egg=qiwis`
+1. `pip install -e git+https://github.com/snu-quiqcl/qiwis.git@v2.0.1#egg=qiwis`  
+For details, refer to [VCS Support](https://pip.pypa.io/en/stable/topics/vcs-support/).
 
 - Using git directly
 1. `git clone ${url}`: The default branch is `develop`, not `main`. There is no guarantee for stability.

--- a/examples/numgen.py
+++ b/examples/numgen.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 App module for generating and showing a random number.
 """

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if sys.version_info[:2] < (3, 7):
 
 setup(
     name="qiwis",
-    version="2.0.1",  # indicate the following version
+    version="2.0.2",
     author="QuIQCL",
     author_email="kangz12345@snu.ac.kr",
     url="https://github.com/snu-quiqcl/qiwis",
@@ -19,7 +19,7 @@ setup(
     long_description=
         "A framework for integration of PyQt widgets where they can communicate with each other. "
         "This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.",
-    download_url="https://github.com/snu-quiqcl/qiwis/releases/tag/v2.0.1",
+    download_url="https://github.com/snu-quiqcl/qiwis/releases/tag/v2.0.2",
     license="MIT license",
     install_requires=["pyqt5"],
     py_modules=["qiwis"],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ Set-up file for releasing this package.
 """
 
 import sys
-from setuptools import setup, find_packages
+from setuptools import setup
 
 if sys.version_info[:2] < (3, 7):
     print("You need Python 3.7+")
@@ -22,7 +22,7 @@ setup(
     download_url="https://github.com/snu-quiqcl/qiwis/releases/tag/v2.0.1",
     license="MIT license",
     install_requires=["pyqt5"],
-    packages=find_packages(include=["qiwis"]),
+    py_modules=["qiwis"],
     entry_points={
         "console_scripts": ["qiwis = qiwis:main"]
     }


### PR DESCRIPTION
As @kangz12345 found out the solution in #176, I resolved the error using `py_modules` in `setup.py`.

I modified something as follows:
- The version to `2.0.2`
- The download url in accordance with the latest version
- How to use `qiwis`
- Remove not used comment in `numgen` example (It was used when we ran the `numgen` app directly)

This PR wil close #175.