### PR TITLE
Log with `logging` module in `qiwis`

### DIFF
--- a/qiwis.py
+++ b/qiwis.py
@@ -320,7 +320,10 @@ class Qiwis(QObject):
         try:
             subscribers.remove(app)
         except KeyError:
+            logger.error("The app %s tried to unsubscribe from %s, "
+                         "which it does not subscribe to", app, channel)
             return False
+        logger.info("The app %s unsubscribed from %s", app, channel)
         return True
 
     @pyqtSlot(str, str)

--- a/qiwis.py
+++ b/qiwis.py
@@ -360,6 +360,7 @@ class Qiwis(QObject):
         for name, arg in args.items():
             cls = signature.parameters[name].annotation
             parsedArgs[name] = loads(cls, arg) if issubclass(cls, Serializable) else arg
+        logger.debug("Parsed arguments %s to %s", args, parsedArgs)
         return parsedArgs
 
     def _handleQiwiscall(self, sender: str, msg: str) -> Any:
@@ -413,11 +414,14 @@ class Qiwis(QObject):
             value = self._handleQiwiscall(sender, msg)
         except Exception as error:  # pylint: disable=broad-exception-caught
             result = QiwiscallResult(done=True, success=False, error=repr(error))
+            logger.exception("Qiwiscall failed")
         else:
             if isinstance(value, Serializable):
                 value = dumps(value)
             result = QiwiscallResult(done=True, success=True, value=value)
+            logger.info("Qiwiscall success")
         self._apps[sender].qiwiscallReturned.emit(msg, dumps(result))
+        logger.info("Qiwiscall result is reported")
 
 
 class BaseApp(QObject):

--- a/qiwis.py
+++ b/qiwis.py
@@ -577,9 +577,11 @@ class QiwiscallProxy:  # pylint: disable=too-few-public-methods
             result = QiwiscallResult(done=False, success=False)
             msg = dumps(info)
             if msg in self.results:
-                logger.warning("Duplicate message is ignored: %s", msg)
+                logger.warning("Duplicate qiwiscall request: %s, "
+                               "the new result overwrites the previous one", msg)
             self.results[msg] = result
             self.requested.emit(msg)
+            logger.debug("Requested a qiwiscall: %s converted from %s", msg, info)
             return result
         return proxy
 
@@ -603,6 +605,7 @@ class QiwiscallProxy:  # pylint: disable=too-few-public-methods
         _result.value = result.value
         _result.success = result.success
         _result.done = result.done
+        logger.debug("Qiwiscall result is updated: %s", _result)
 
 
 @contextmanager

--- a/qiwis.py
+++ b/qiwis.py
@@ -9,15 +9,15 @@ Usage:
     python -m qiwis (-s <SETUP_PATH>)
 """
 
-import sys
-import os
 import argparse
-import json
+import dataclasses
+import functools
 import importlib
 import importlib.util
 import inspect
-import dataclasses
-import functools
+import json
+import os
+import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import (

--- a/qiwis.py
+++ b/qiwis.py
@@ -7,6 +7,9 @@ Using a set-up file written by a user, it sets up apps.
 
 Usage:
     python -m qiwis (-s <SETUP_PATH>)
+
+Logging:
+    The module-level logger name is __name__.
 """
 
 import argparse
@@ -16,6 +19,7 @@ import importlib
 import importlib.util
 import inspect
 import json
+import logging
 import os
 import sys
 from collections import defaultdict
@@ -29,6 +33,9 @@ from PyQt5.QtWidgets import QApplication, QMainWindow, QDockWidget, QMessageBox,
 
 
 T = TypeVar("T")
+
+
+logger = logging.getLogger(__name__)
 
 
 class Serializable:  # pylint: disable=too-few-public-methods

--- a/qiwis.py
+++ b/qiwis.py
@@ -178,6 +178,7 @@ class Qiwis(QObject):
         """
         for name, info in appInfos.items():
             self.createApp(name, info)
+        logger.info("Loaded %d app(s)", len(appInfos))
 
     def addFrame(self, name: str, frame: QWidget, info: AppInfo):
         """Adds a frame of the app and wraps it with a dock widget.
@@ -200,6 +201,7 @@ class Qiwis(QObject):
         if info.show:
             self.mainWindow.addDockWidget(area, dockWidget)
         self._dockWidgets[name].append(dockWidget)
+        logger.info("Added a frame to the app %s: %s", name, info)
 
     def removeFrame(self, name: str, dockWidget: QDockWidget):
         """Removes the frame from the main window.
@@ -213,6 +215,7 @@ class Qiwis(QObject):
         self.mainWindow.removeDockWidget(dockWidget)
         self._dockWidgets[name].remove(dockWidget)
         dockWidget.deleteLater()
+        logger.info("Removed a frame from the app %s", name)
 
     def appNames(self) -> Tuple[str]:
         """Returns the names of the apps including whose frames are hidden."""
@@ -242,6 +245,7 @@ class Qiwis(QObject):
         for frame in app.frames():
             self.addFrame(name, frame, info)
         self._apps[name] = app
+        logger.info("Created an app %s: %s", name, info)
 
     def destroyApp(self, name: str):
         """Destroys an app.
@@ -256,6 +260,7 @@ class Qiwis(QObject):
         for apps in self._subscribers.values():
             apps.discard(name)
         self._apps.pop(name).deleteLater()
+        logger.info("Destroyed the app %s", name)
 
     def updateFrames(self, name: str):
         """Updates the frames of an app.
@@ -273,6 +278,7 @@ class Qiwis(QObject):
             self.removeFrame(name, orgFrames[frame])
         for frame in newFramesSet - orgFramesSet:
             self.addFrame(name, frame, info)
+        logger.info("Updated frames: %d -> %d", len(orgFramesSet), len(newFramesSet))
 
     def channelNames(self) -> Tuple[str]:
         """Returns the names of the channels."""

--- a/qiwis.py
+++ b/qiwis.py
@@ -478,8 +478,10 @@ class BaseApp(QObject):
         try:
             msg = json.dumps(content)
         except TypeError:
-            logger.exception("Failed to json.dumps() the content: %s", str(content))
+            logger.exception("Failed to broadcast the content: %s", content)
         else:
+            logger.debug("Broadcast a message to %s: %s converted from %s",
+                         channelName, msg, content)
             self.broadcastRequested.emit(channelName, msg)
 
     def receivedSlot(self, channelName: str, content: Any):
@@ -504,8 +506,10 @@ class BaseApp(QObject):
         try:
             content = json.loads(msg)
         except json.JSONDecodeError:
-            logger.exception("Failed to json.loads() the message: %s", msg)
+            logger.exception("Failed to receive the message: %s", msg)
         else:
+            logger.debug("Received a content from %s: %s converted from %s",
+                         channelName, content, msg)
             self.receivedSlot(channelName, content)
 
     @pyqtSlot(str, str)
@@ -520,8 +524,10 @@ class BaseApp(QObject):
         try:
             result = loads(QiwiscallResult, msg)
         except json.JSONDecodeError:
-            logger.exception("Failed to loads() the message: %s", msg)
+            logger.exception("Failed to received the qiwiscall result message: %s", msg)
         else:
+            logger.debug("Received a qiwiscall result %s for the request %s, "
+                         "converted from the message %s", result, request, msg)
             self.qiwiscall.update_result(request, result)
 
 

--- a/qiwis.py
+++ b/qiwis.py
@@ -668,17 +668,20 @@ def _read_setup_file(setup_path: str) -> Mapping[str, AppInfo]:
         setup_data: Dict[str, Dict[str, dict]] = json.load(setup_file)
     app_dict = setup_data.get("app", {})
     app_infos = {name: AppInfo(**info) for (name, info) in app_dict.items()}
+    logger.info("Loaded %d app infos from %s", len(app_infos), setup_path)
     return app_infos
 
 
 def main():
     """Main function that runs when qiwis module is executed rather than imported."""
     args = _get_argparser().parse_args()
+    logger.info("Parsed arguments: %s", args)
     # read set-up information
     app_infos = _read_setup_file(args.setup_path)
     # start GUI
     qapp = QApplication(sys.argv)
     _qiwis = Qiwis(app_infos)
+    logger.info("Now the QApplication starts")
     qapp.exec_()
 
 

--- a/qiwis.py
+++ b/qiwis.py
@@ -212,10 +212,11 @@ class Qiwis(QObject):
             name: A name of app.
             dockWidget: A dock widget to remove.
         """
+        frameName = dockWidget.widget().__class__.__name__
         self.mainWindow.removeDockWidget(dockWidget)
         self._dockWidgets[name].remove(dockWidget)
         dockWidget.deleteLater()
-        logger.info("Removed a frame from the app %s", name)
+        logger.info("Removed a frame %s from the app %s", frameName, name)
 
     def appNames(self) -> Tuple[str]:
         """Returns the names of the apps including whose frames are hidden."""

--- a/qiwis.py
+++ b/qiwis.py
@@ -300,7 +300,11 @@ class Qiwis(QObject):
             app: The name of the app which wants to subscribe to the channel.
             channel: The target channel name.
         """
-        self._subscribers[channel].add(app)
+        if app in self._subscribers[channel]:
+            logger.warning("The app %s already subscribes to %s", app, channel)
+        else:
+            self._subscribers[channel].add(app)
+            logger.info("The app %s now subscribes to %s", app, channel)
 
     def unsubscribe(self, app: str, channel: str) -> bool:
         """Cancels the subscription of the app to the channel.


### PR DESCRIPTION
I added logging parts.
One can check the logging as follows:

![Screenshot 2023-06-06 at 12 24 01](https://github.com/snu-quiqcl/qiwis/assets/8445906/3e0e0c75-6788-46aa-9ffd-42b5e467907a)

(The stack trace is printed by the logger, and the program is not dead, i.e., the exception is caught normally.)

If you are not familiar to `logging`, then I can make a test script for you.

This closes #180.