### PR TITLE
Handle re-creating the existing app

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -25,5 +25,5 @@ jobs:
         sudo apt-get install python3-pyqt5
     - name: Unittest the code with coverage
       run: |
-        xvfb-run `which coverage` run -m unittest test
-        xvfb-run `which coverage` report qiwis.py
+        xvfb-run `which coverage` run --source=qiwis -m unittest discover
+        xvfb-run `which coverage` report

--- a/qiwis.py
+++ b/qiwis.py
@@ -232,7 +232,8 @@ class Qiwis(QObject):
         Args:
             name: The name of the app to be added.
             info: The AppInfo object describing the app.
-            replace: If True, the existing app will be replaced. Otherwise, nothing happens.
+            replace: It describes the behavior when trying to create an existing app.
+              If True, the original app will be replaced. Otherwise, it will be ignored.
         """
         if name in self._apps:
             if replace:

--- a/qiwis.py
+++ b/qiwis.py
@@ -226,13 +226,20 @@ class Qiwis(QObject):
         """Returns the names of the apps including whose frames are hidden."""
         return tuple(self._apps.keys())
 
-    def createApp(self, name: str, info: AppInfo):
+    def createApp(self, name: str, info: AppInfo, replace: bool = False):
         """Creates an app and shows their frames using set-up environment.
         
         Args:
-            name: A name of app.
-            info: An AppInfo object describing the app.
+            name: The name of the app to be added.
+            info: The AppInfo object describing the app.
+            replace: If True, the existing app will be replaced. Otherwise, nothing happens.
         """
+        if name in self._apps:
+            if replace:
+                self.destroyApp(name)
+            else:
+                logger.error("The app %s already exists.", name)
+                return
         with _add_to_path(os.path.dirname(info.path)):
             module = importlib.import_module(info.module)
         cls = getattr(module, info.cls)

--- a/test.py
+++ b/test.py
@@ -117,19 +117,13 @@ class QiwisTestWithApps(unittest.TestCase):
         app_.frames.return_value = (QWidget(),)
         cls = mock.MagicMock(return_value=app_)
         setattr(self.mocked_import_module.return_value, "cls2", cls)
+        appInfo = qiwis.AppInfo(module="module2", cls="cls2")
         # The original app will not be replaced.
-        self.qiwis.createApp(
-            "app2",
-            qiwis.AppInfo(module="module2", cls="cls2")
-        )
+        self.qiwis.createApp("app2", appInfo)
         mocked_destroy_app.assert_not_called()
         self.assertEqual(self.qiwis._apps["app2"], orgApp)
         # The original app will be replaced.
-        self.qiwis.createApp(
-            "app2",
-            qiwis.AppInfo(module="module2", cls="cls2"),
-            True
-        )
+        self.qiwis.createApp("app2", appInfo, True)
         mocked_destroy_app.assert_called_once_with("app2")
         self.assertNotEqual(self.qiwis._apps["app2"], orgApp)
 

--- a/test.py
+++ b/test.py
@@ -167,11 +167,15 @@ class QiwisTestWithApps(unittest.TestCase):
             )
 
     def test_subscribe(self):
+        self.assertNotIn("app1", self.qiwis._subscribers["ch3"])
         self.qiwis.subscribe("app1", "ch3")
         self.assertIn("app1", self.qiwis._subscribers["ch3"])
-        # The app already subscribes to the channel.
-        orgSubscribers = self.qiwis._subscribers["ch3"]
+    
+    def test_subscribe_duplicate(self):
+        """Tests for the case where trying to subscribe to a channel already subscribed to."""
         self.qiwis.subscribe("app1", "ch3")
+        orgSubscribers = self.qiwis._subscribers["ch3"]
+        self.qiwis.subscribe("app1", "ch3")  # Try to subscribe to the channel again.
         self.assertEqual(self.qiwis._subscribers["ch3"], orgSubscribers)
 
     def test_unsubcribe(self):

--- a/test.py
+++ b/test.py
@@ -172,6 +172,10 @@ class QiwisTestWithApps(unittest.TestCase):
                 {name for name, info in APP_INFOS.items() if channel in info.channel}
             )
 
+    def test_subscribe(self):
+        self.qiwis.subscribe("app1", "ch3")
+        self.assertIn("app1", self.qiwis._subscribers["ch3"])
+
     def test_unsubcribe(self):
         self.assertEqual(self.qiwis.unsubscribe("app1", "ch1"), True)
         self.assertNotIn("app1", self.qiwis._subscribers["ch1"])

--- a/test.py
+++ b/test.py
@@ -109,7 +109,7 @@ class QiwisTestWithApps(unittest.TestCase):
         self.assertIn("app3", self.qiwis._subscribers["ch1"])
 
     @mock.patch("qiwis.Qiwis.destroyApp")
-    def test_create_existing_app(self, mockedDestroyApp):
+    def test_create_existing_app(self, mocked_destroy_app):
         """Tests for the case where trying to create an existing app."""
         orgApp = self.qiwis._apps["app2"]
         app_ = mock.MagicMock()
@@ -122,7 +122,7 @@ class QiwisTestWithApps(unittest.TestCase):
             "app2",
             qiwis.AppInfo(module="module2", cls="cls2")
         )
-        mockedDestroyApp.assert_not_called()
+        mocked_destroy_app.assert_not_called()
         self.assertEqual(self.qiwis._apps["app2"], orgApp)
         # The original app will be replaced.
         self.qiwis.createApp(
@@ -130,7 +130,7 @@ class QiwisTestWithApps(unittest.TestCase):
             qiwis.AppInfo(module="module2", cls="cls2"),
             True
         )
-        mockedDestroyApp.assert_called_once_with("app2")
+        mocked_destroy_app.assert_called_once_with("app2")
         self.assertNotEqual(self.qiwis._apps["app2"], orgApp)
 
     def test_destroy_app(self):

--- a/test.py
+++ b/test.py
@@ -101,7 +101,7 @@ class QiwisTestWithApps(unittest.TestCase):
         setattr(self.mocked_import_module.return_value, "cls3", cls)
         self.qiwis.createApp(
             "app3",
-            qiwis.AppInfo(**{"module": "module3", "cls": "cls3", "channel": ["ch1"]})
+            qiwis.AppInfo(module="module3", cls="cls3", channel=["ch1"])
         )
         self.mocked_import_module.assert_called_with("module3")
         self.assertEqual(self.qiwis._apps["app3"].cls, "cls3")
@@ -120,14 +120,14 @@ class QiwisTestWithApps(unittest.TestCase):
         # The original app will not be replaced.
         self.qiwis.createApp(
             "app2",
-            qiwis.AppInfo(**{"module": "module2", "cls": "cls2"})
+            qiwis.AppInfo(module="module2", cls="cls2")
         )
         mockedDestroyApp.assert_not_called()
         self.assertEqual(self.qiwis._apps["app2"], orgApp)
         # The original app will be replaced.
         self.qiwis.createApp(
             "app2",
-            qiwis.AppInfo(**{"module": "module2", "cls": "cls2"}),
+            qiwis.AppInfo(module="module2", cls="cls2"),
             True
         )
         mockedDestroyApp.assert_called_once_with("app2")

--- a/test.py
+++ b/test.py
@@ -169,6 +169,10 @@ class QiwisTestWithApps(unittest.TestCase):
     def test_subscribe(self):
         self.qiwis.subscribe("app1", "ch3")
         self.assertIn("app1", self.qiwis._subscribers["ch3"])
+        # The app already subscribes to the channel.
+        orgSubscribers = self.qiwis._subscribers["ch3"]
+        self.qiwis.subscribe("app1", "ch3")
+        self.assertEqual(self.qiwis._subscribers["ch3"], orgSubscribers)
 
     def test_unsubcribe(self):
         self.assertEqual(self.qiwis.unsubscribe("app1", "ch1"), True)

--- a/test.py
+++ b/test.py
@@ -170,7 +170,7 @@ class QiwisTestWithApps(unittest.TestCase):
         self.assertNotIn("app1", self.qiwis._subscribers["ch3"])
         self.qiwis.subscribe("app1", "ch3")
         self.assertIn("app1", self.qiwis._subscribers["ch3"])
-    
+
     def test_subscribe_duplicate(self):
         """Tests for the case where trying to subscribe to a channel already subscribed to."""
         self.qiwis.subscribe("app1", "ch3")


### PR DESCRIPTION
This PR will close #190.

I implement two things.
1. Add the param `replace` to handle the case where trying to re-create an existing app.
2. Update `createApp()` test and make `subscribe()` test

Suprisignly, we haven't tested for `subscribe()`, thus the coverage wasn't 100%.
I tried to implement it, but encountered a minor problem.

I should handle the case where the app tries to subscribe a channel already subscribed to.
But, I think there is no way to distinguish two cases (line 316 and 318), because we cannot mock `set.add()`.
Can I test two cases with mocking `logger`?