### PR TITLE
Support a central widget

### DIFF
--- a/examples/dbmgr.py
+++ b/examples/dbmgr.py
@@ -194,7 +194,7 @@ class DBMgrApp(BaseApp):
                     module="examples.datacalc",
                     cls="DataCalcApp",
                     show=True,
-                    pos="top",
+                    pos="center",
                     channel=["db"],
                     args={
                         "tables": {

--- a/qiwis.py
+++ b/qiwis.py
@@ -60,18 +60,21 @@ class AppInfo(Serializable):
     """Information required to create an app.
     
     Fields:
-        module: Module name in which the app class resides.
-        cls: App class name.
-        path: System path for module importing.
-        show: Whether to show the app frames on creation.
-        pos: Position on the main window; refer to Qt.DockWidgetArea enum.
-          Should be one of "left", "right", "top", or "bottom", case-sensitive.
-          Otherwise, defaults to Qt.LeftDockWidgetArea.
-        channel: Channels which the app subscribes to.
-        args: Keyword argument dictionary of the app class constructor.
-          It must exclude name and parent arguments. Even if they exist, they will be ignored.
+        module: The module name of the app class.
+        cls: The name of the app class.
+        path: The path for importing the module.
+        show: Whether to show frames of the app.
+        pos: The position of the frames on the GUI.
+          It should be one of "center", "left", "right", "top", or "bottom", case-sensitive.
+          Otherwise, it is set to "left".
+          In the case "center", the frame is wrapped by QMdiSubWindow.
+          In the other cases, the frame is wrapped by QDockWidget and
+            its position follows Qt.DockWidgetArea.
+        channel: The list of channels which the app subscribes to.
+        args: The dictionary for the keyword arguments of the app class constructor.
+          It should exclude the name and parent arguments.
           None for initializing the app with default values,
-          where only name and parent arguments will be passed.
+            where only the name and parent arguments will be passed.
     """
     module: str
     cls: str

--- a/qiwis.py
+++ b/qiwis.py
@@ -202,6 +202,7 @@ class Qiwis(QObject):
             outerWidget = QMdiSubWindow(self.centralWidget)
             outerWidget.setWindowTitle(name)
             outerWidget.setWidget(frame)
+            outerWidget.show()
         else:
             outerWidget = QDockWidget(name, self.mainWindow)
             outerWidget.setWidget(frame)

--- a/qiwis.py
+++ b/qiwis.py
@@ -199,13 +199,13 @@ class Qiwis(QObject):
             info: An AppInfo object describing the app.
         """
         if info.pos == "center":
-            outerWidget = QMdiSubWindow(self.centralWidget)
-            outerWidget.setWindowTitle(name)
-            outerWidget.setWidget(frame)
-            outerWidget.show()
+            wrapperWidget = QMdiSubWindow(self.centralWidget)
+            wrapperWidget.setWindowTitle(name)
+            wrapperWidget.setWidget(frame)
+            wrapperWidget.show()
         else:
-            outerWidget = QDockWidget(name, self.mainWindow)
-            outerWidget.setWidget(frame)
+            wrapperWidget = QDockWidget(name, self.mainWindow)
+            wrapperWidget.setWidget(frame)
             area = {
                 "left": Qt.LeftDockWidgetArea,
                 "right": Qt.RightDockWidgetArea,
@@ -218,28 +218,28 @@ class Qiwis(QObject):
                     if self.mainWindow.dockWidgetArea(dockWidget_) == area
                 ]
                 if areaDockWidgets:
-                    self.mainWindow.tabifyDockWidget(areaDockWidgets[-1], outerWidget)
+                    self.mainWindow.tabifyDockWidget(areaDockWidgets[-1], wrapperWidget)
                 else:
-                    self.mainWindow.addDockWidget(area, outerWidget)
-        self._wrapperWidgets[name].append(outerWidget)
+                    self.mainWindow.addDockWidget(area, wrapperWidget)
+        self._wrapperWidgets[name].append(wrapperWidget)
         logger.info("Added a frame to the app %s: %s", name, info)
 
-    def removeFrame(self, name: str, outerWidget: Union[QMdiSubWindow, QDockWidget]):
+    def removeFrame(self, name: str, wrapperWidget: Union[QMdiSubWindow, QDockWidget]):
         """Removes the frame from the main window.
         
         This is not a qiwiscall because QMdiSubWindow and QDockWidget are not Serializable.
         
         Args:
             name: The name of the app.
-            outerWidget: The outer widget to remove.
+            wrapperWidget: The wrapper widget to remove.
         """
-        frameName = outerWidget.widget().__class__.__name__
-        if isinstance(outerWidget, QMdiSubWindow):
-            self.centralWidget.removeSubWindow(outerWidget)
+        frameName = wrapperWidget.widget().__class__.__name__
+        if isinstance(wrapperWidget, QMdiSubWindow):
+            self.centralWidget.removeSubWindow(wrapperWidget)
         else:
-            self.mainWindow.removeDockWidget(outerWidget)
-        self._wrapperWidgets[name].remove(outerWidget)
-        outerWidget.deleteLater()
+            self.mainWindow.removeDockWidget(wrapperWidget)
+        self._wrapperWidgets[name].remove(wrapperWidget)
+        wrapperWidget.deleteLater()
         logger.info("Removed a frame %s from the app %s", frameName, name)
 
     def appNames(self) -> Tuple[str]:
@@ -286,9 +286,9 @@ class Qiwis(QObject):
         Args:
             name: A name of the app to destroy.
         """
-        outerWidgets = self._wrapperWidgets[name]
-        for outerWidget in outerWidgets:
-            self.removeFrame(name, outerWidget)
+        wrapperWidgets = self._wrapperWidgets[name]
+        for wrapperWidget in wrapperWidgets:
+            self.removeFrame(name, wrapperWidget)
         del self._wrapperWidgets[name]
         for apps in self._subscribers.values():
             apps.discard(name)
@@ -304,8 +304,8 @@ class Qiwis(QObject):
         app = self._apps[name]
         info = self.appInfos[name]
         orgFrames = {
-            outerWidget.widget(): outerWidget
-            for outerWidget in self._wrapperWidgets[name]
+            wrapperWidget.widget(): wrapperWidget
+            for wrapperWidget in self._wrapperWidgets[name]
         }
         newFrames = app.frames()
         orgFramesSet = set(orgFrames)

--- a/qiwis.py
+++ b/qiwis.py
@@ -168,7 +168,7 @@ class Qiwis(QObject):
         self.mainWindow = QMainWindow()
         self.centralWidget = QMdiArea()
         self.mainWindow.setCentralWidget(self.centralWidget)
-        self._outerWidgets = defaultdict(list)
+        self._wrapperWidgets = defaultdict(list)
         self._apps: Dict[str, BaseApp] = {}
         self._subscribers: DefaultDict[str, Set[str]] = defaultdict(set)
         appInfos = appInfos if appInfos else {}
@@ -221,7 +221,7 @@ class Qiwis(QObject):
                     self.mainWindow.tabifyDockWidget(areaDockWidgets[-1], outerWidget)
                 else:
                     self.mainWindow.addDockWidget(area, outerWidget)
-        self._outerWidgets[name].append(outerWidget)
+        self._wrapperWidgets[name].append(outerWidget)
         logger.info("Added a frame to the app %s: %s", name, info)
 
     def removeFrame(self, name: str, outerWidget: Union[QMdiSubWindow, QDockWidget]):
@@ -238,7 +238,7 @@ class Qiwis(QObject):
             self.centralWidget.removeSubWindow(outerWidget)
         else:
             self.mainWindow.removeDockWidget(outerWidget)
-        self._outerWidgets[name].remove(outerWidget)
+        self._wrapperWidgets[name].remove(outerWidget)
         outerWidget.deleteLater()
         logger.info("Removed a frame %s from the app %s", frameName, name)
 
@@ -286,10 +286,10 @@ class Qiwis(QObject):
         Args:
             name: A name of the app to destroy.
         """
-        outerWidgets = self._outerWidgets[name]
+        outerWidgets = self._wrapperWidgets[name]
         for outerWidget in outerWidgets:
             self.removeFrame(name, outerWidget)
-        del self._outerWidgets[name]
+        del self._wrapperWidgets[name]
         for apps in self._subscribers.values():
             apps.discard(name)
         self._apps.pop(name).deleteLater()
@@ -303,7 +303,7 @@ class Qiwis(QObject):
         """
         app = self._apps[name]
         info = self.appInfos[name]
-        orgFrames = {outerWidget.widget(): outerWidget for outerWidget in self._outerWidgets[name]}
+        orgFrames = {outerWidget.widget(): outerWidget for outerWidget in self._wrapperWidgets[name]}
         newFrames = app.frames()
         orgFramesSet = set(orgFrames)
         newFramesSet = set(newFrames)

--- a/qiwis.py
+++ b/qiwis.py
@@ -303,7 +303,10 @@ class Qiwis(QObject):
         """
         app = self._apps[name]
         info = self.appInfos[name]
-        orgFrames = {outerWidget.widget(): outerWidget for outerWidget in self._wrapperWidgets[name]}
+        orgFrames = {
+            outerWidget.widget(): outerWidget
+            for outerWidget in self._wrapperWidgets[name]
+        }
         newFrames = app.frames()
         orgFramesSet = set(orgFrames)
         newFramesSet = set(newFrames)

--- a/qiwis.py
+++ b/qiwis.py
@@ -196,12 +196,12 @@ class Qiwis(QObject):
             info: An AppInfo object describing the app.
         """
         if info.pos == "center":
-            widget = QMdiSubWindow(self.centralWidget)
-            widget.setWindowTitle(name)
-            widget.setWidget(frame)
+            outerWidget = QMdiSubWindow(self.centralWidget)
+            outerWidget.setWindowTitle(name)
+            outerWidget.setWidget(frame)
         else:
-            dockWidget = QDockWidget(name, self.mainWindow)
-            dockWidget.setWidget(frame)
+            outerWidget = QDockWidget(name, self.mainWindow)
+            outerWidget.setWidget(frame)
             area = {
                 "left": Qt.LeftDockWidgetArea,
                 "right": Qt.RightDockWidgetArea,
@@ -214,10 +214,10 @@ class Qiwis(QObject):
                     if self.mainWindow.dockWidgetArea(dockWidget_) == area
                 ]
                 if areaDockWidgets:
-                    self.mainWindow.tabifyDockWidget(areaDockWidgets[-1], dockWidget)
+                    self.mainWindow.tabifyDockWidget(areaDockWidgets[-1], outerWidget)
                 else:
-                    self.mainWindow.addDockWidget(area, dockWidget)
-            self._outerWidgets[name].append(dockWidget)
+                    self.mainWindow.addDockWidget(area, outerWidget)
+        self._outerWidgets[name].append(outerWidget)
         logger.info("Added a frame to the app %s: %s", name, info)
 
     def removeFrame(self, name: str, outerWidget: Union[QMdiSubWindow, QDockWidget]):
@@ -299,7 +299,7 @@ class Qiwis(QObject):
         """
         app = self._apps[name]
         info = self.appInfos[name]
-        orgFrames = {dockWidget.widget(): dockWidget for dockWidget in self._outerWidgets[name]}
+        orgFrames = {outerWidget.widget(): outerWidget for outerWidget in self._outerWidgets[name]}
         newFrames = app.frames()
         orgFramesSet = set(orgFrames)
         newFramesSet = set(newFrames)

--- a/qiwis.py
+++ b/qiwis.py
@@ -214,8 +214,8 @@ class Qiwis(QObject):
             }.get(info.pos, Qt.LeftDockWidgetArea)
             if info.show:
                 areaDockWidgets = [
-                    dockWidget_ for dockWidget_ in self.mainWindow.findChildren(QDockWidget)
-                    if self.mainWindow.dockWidgetArea(dockWidget_) == area
+                    dockWidget for dockWidget in self.mainWindow.findChildren(QDockWidget)
+                    if self.mainWindow.dockWidgetArea(dockWidget) == area
                 ]
                 if areaDockWidgets:
                     self.mainWindow.tabifyDockWidget(areaDockWidgets[-1], wrapperWidget)

--- a/qiwis.py
+++ b/qiwis.py
@@ -189,7 +189,7 @@ class Qiwis(QObject):
         logger.info("Loaded %d app(s)", len(appInfos))
 
     def addFrame(self, name: str, frame: QWidget, info: AppInfo):
-        """Adds a frame of the app and wraps it with a dock widget.
+        """Adds the given frame and wraps it with a wrapper widget.
 
         This is not a qiwiscall because QWidget is not Serializable.
         

--- a/qiwis.py
+++ b/qiwis.py
@@ -282,9 +282,9 @@ class Qiwis(QObject):
         Args:
             name: A name of the app to destroy.
         """
-        dockWidgets = self._outerWidgets[name]
-        for dockWidget in dockWidgets:
-            self.removeFrame(name, dockWidget)
+        outerWidgets = self._outerWidgets[name]
+        for outerWidget in outerWidgets:
+            self.removeFrame(name, outerWidget)
         del self._outerWidgets[name]
         for apps in self._subscribers.values():
             apps.discard(name)

--- a/test.py
+++ b/test.py
@@ -94,10 +94,10 @@ class QiwisTestWithApps(unittest.TestCase):
         self.assertEqual(appNamesSet, set(APP_INFOS))
 
     def test_create_app(self):
-        app_ = mock.MagicMock()
-        app_.cls = "cls3"
-        app_.frames.return_value = (QWidget(),)
-        cls = mock.MagicMock(return_value=app_)
+        app = mock.MagicMock()
+        app.cls = "cls3"
+        app.frames.return_value = (QWidget(),)
+        cls = mock.MagicMock(return_value=app)
         setattr(self.mocked_import_module.return_value, "cls3", cls)
         self.qiwis.createApp(
             "app3",
@@ -111,10 +111,10 @@ class QiwisTestWithApps(unittest.TestCase):
     def test_create_existing_app(self):
         """Tests for the case where trying to create an existing app."""
         orgApp = self.qiwis._apps["app2"]
-        app_ = mock.MagicMock()
-        app_.cls = "cls2"
-        app_.frames.return_value = (QWidget(),)
-        cls = mock.MagicMock(return_value=app_)
+        app = mock.MagicMock()
+        app.cls = "cls2"
+        app.frames.return_value = (QWidget(),)
+        cls = mock.MagicMock(return_value=app)
         setattr(self.mocked_import_module.return_value, "cls2", cls)
         appInfo = qiwis.AppInfo(module="module2", cls="cls2")
         with mock.patch.object(self.qiwis, "destroyApp") as mocked_destroy_app:
@@ -186,8 +186,8 @@ class QiwisTestWithApps(unittest.TestCase):
     def test_broadcast(self):
         for channelName in self.channels:
             self.qiwis._broadcast(channelName, "test_msg")
-        for name, app_ in self.qiwis._apps.items():
-            self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
+        for name, app in self.qiwis._apps.items():
+            self.assertEqual(len(APP_INFOS[name].channel), app.received.emit.call_count)
 
 
 class QiwisTestWithoutApps(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -137,20 +137,20 @@ class QiwisTestWithApps(unittest.TestCase):
 
     def test_update_frames_inclusive(self):
         """Tests for the case where a new frame is added in the return of frames()."""
-        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._wrapperWidgets["app1"]}
+        orgFramesSet = {wrapperWidget.widget() for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = orgFramesSet | {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._wrapperWidgets["app1"]}
+        finalFramesSet = {wrapperWidget.widget() for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
         self.assertEqual(finalFramesSet, newFramesSet)
 
     def test_update_frames_exclusive(self):
         """Tests for the case where a new frame replaced the return of frames()."""
-        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._wrapperWidgets["app1"]}
+        orgFramesSet = {wrapperWidget.widget() for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._wrapperWidgets["app1"]}
+        finalFramesSet = {wrapperWidget.widget() for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
         self.assertFalse(finalFramesSet & orgFramesSet)
         self.assertEqual(finalFramesSet, newFramesSet)
 

--- a/test.py
+++ b/test.py
@@ -67,10 +67,10 @@ class QiwisTestWithApps(unittest.TestCase):
         self.import_module_patcher = mock.patch("importlib.import_module")
         self.mocked_import_module = self.import_module_patcher.start()
         for appInfo in APP_INFOS.values():
-            app_ = mock.MagicMock()
-            app_.cls = appInfo.cls
-            app_.frames.return_value = (QWidget(),)
-            cls = mock.MagicMock(return_value=app_)
+            app = mock.MagicMock()
+            app.cls = appInfo.cls
+            app.frames.return_value = (QWidget(),)
+            cls = mock.MagicMock(return_value=app)
             setattr(self.mocked_import_module.return_value, appInfo.cls, cls)
         self.channels = set()
         for appInfo in APP_INFOS.values():

--- a/test.py
+++ b/test.py
@@ -85,7 +85,7 @@ class QiwisTestWithApps(unittest.TestCase):
         for name, info in APP_INFOS.items():
             self.mocked_import_module.assert_any_call(info.module)
             self.assertEqual(self.qiwis._apps[name].cls, info.cls)
-            self.assertIn(name, self.qiwis._outerWidgets)
+            self.assertIn(name, self.qiwis._wrapperWidgets)
         for channel in self.channels:
             self.assertIn(channel, self.qiwis._subscribers)
 
@@ -105,7 +105,7 @@ class QiwisTestWithApps(unittest.TestCase):
         )
         self.mocked_import_module.assert_called_with("module3")
         self.assertEqual(self.qiwis._apps["app3"].cls, "cls3")
-        self.assertIn("app3", self.qiwis._outerWidgets)
+        self.assertIn("app3", self.qiwis._wrapperWidgets)
         self.assertIn("app3", self.qiwis._subscribers["ch1"])
 
     def test_create_existing_app(self):
@@ -131,26 +131,26 @@ class QiwisTestWithApps(unittest.TestCase):
         for name, info in APP_INFOS.items():
             self.qiwis.destroyApp(name)
             self.assertNotIn(name, self.qiwis._apps)
-            self.assertNotIn(name, self.qiwis._outerWidgets)
+            self.assertNotIn(name, self.qiwis._wrapperWidgets)
             for channel in info.channel:
                 self.assertNotIn(name, self.qiwis._subscribers[channel])
 
     def test_update_frames_inclusive(self):
         """Tests for the case where a new frame is added in the return of frames()."""
-        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._outerWidgets["app1"]}
+        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = orgFramesSet | {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._outerWidgets["app1"]}
+        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._wrapperWidgets["app1"]}
         self.assertEqual(finalFramesSet, newFramesSet)
 
     def test_update_frames_exclusive(self):
         """Tests for the case where a new frame replaced the return of frames()."""
-        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._outerWidgets["app1"]}
+        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._outerWidgets["app1"]}
+        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._wrapperWidgets["app1"]}
         self.assertFalse(finalFramesSet & orgFramesSet)
         self.assertEqual(finalFramesSet, newFramesSet)
 

--- a/test.py
+++ b/test.py
@@ -137,20 +137,20 @@ class QiwisTestWithApps(unittest.TestCase):
 
     def test_update_frames_inclusive(self):
         """Tests for the case where a new frame is added in the return of frames()."""
-        orgFramesSet = {wrapperWidget.widget() for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
+        orgFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = orgFramesSet | {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {wrapperWidget.widget() for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
+        finalFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         self.assertEqual(finalFramesSet, newFramesSet)
 
     def test_update_frames_exclusive(self):
         """Tests for the case where a new frame replaced the return of frames()."""
-        orgFramesSet = {wrapperWidget.widget() for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
+        orgFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {wrapperWidget.widget() for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
+        finalFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         self.assertFalse(finalFramesSet & orgFramesSet)
         self.assertEqual(finalFramesSet, newFramesSet)
 

--- a/test.py
+++ b/test.py
@@ -85,7 +85,7 @@ class QiwisTestWithApps(unittest.TestCase):
         for name, info in APP_INFOS.items():
             self.mocked_import_module.assert_any_call(info.module)
             self.assertEqual(self.qiwis._apps[name].cls, info.cls)
-            self.assertIn(name, self.qiwis._dockWidgets)
+            self.assertIn(name, self.qiwis._outerWidgets)
         for channel in self.channels:
             self.assertIn(channel, self.qiwis._subscribers)
 
@@ -105,7 +105,7 @@ class QiwisTestWithApps(unittest.TestCase):
         )
         self.mocked_import_module.assert_called_with("module3")
         self.assertEqual(self.qiwis._apps["app3"].cls, "cls3")
-        self.assertIn("app3", self.qiwis._dockWidgets)
+        self.assertIn("app3", self.qiwis._outerWidgets)
         self.assertIn("app3", self.qiwis._subscribers["ch1"])
 
     def test_create_existing_app(self):
@@ -131,26 +131,26 @@ class QiwisTestWithApps(unittest.TestCase):
         for name, info in APP_INFOS.items():
             self.qiwis.destroyApp(name)
             self.assertNotIn(name, self.qiwis._apps)
-            self.assertNotIn(name, self.qiwis._dockWidgets)
+            self.assertNotIn(name, self.qiwis._outerWidgets)
             for channel in info.channel:
                 self.assertNotIn(name, self.qiwis._subscribers[channel])
 
     def test_update_frames_inclusive(self):
         """Tests for the case where a new frame is added in the return of frames()."""
-        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._dockWidgets["app1"]}
+        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._outerWidgets["app1"]}
         newFramesSet = orgFramesSet | {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._dockWidgets["app1"]}
+        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._outerWidgets["app1"]}
         self.assertEqual(finalFramesSet, newFramesSet)
 
     def test_update_frames_exclusive(self):
         """Tests for the case where a new frame replaced the return of frames()."""
-        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._dockWidgets["app1"]}
+        orgFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._outerWidgets["app1"]}
         newFramesSet = {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._dockWidgets["app1"]}
+        finalFramesSet = {dockWidget.widget() for dockWidget in self.qiwis._outerWidgets["app1"]}
         self.assertFalse(finalFramesSet & orgFramesSet)
         self.assertEqual(finalFramesSet, newFramesSet)
 


### PR DESCRIPTION
This PR will close #205.

Now, a central widget is supported. The impletations are as follows:
1. The central area is a `QMdiArea` instance.
2. In this area, a `QMdiSubWindow` can be added.
3. If the `pos` argument is set to "center" in `config.json`, each widget of the app will be wrapped in `QMdiSubWindow`.

For test, I modified the position of `datacalc` app to "center".

![image](https://github.com/snu-quiqcl/qiwis/assets/76851886/0d6a2f97-6b76-4600-b793-7d0545f86714)
