### PR TITLE
Enable the central widget, `MdiArea` scrolled

### DIFF
--- a/qiwis.py
+++ b/qiwis.py
@@ -202,6 +202,8 @@ class Qiwis(QObject):
         )
         self.mainWindow = QMainWindow()
         self.centralWidget = MdiArea(background_path)
+        self.centralWidget.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
+        self.centralWidget.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.mainWindow.setCentralWidget(self.centralWidget)
         self._wrapperWidgets = defaultdict(list)
         self._apps: Dict[str, BaseApp] = {}


### PR DESCRIPTION
This closes #221.

I just set the scrollbar policy to show the scrollbar as needed.

![image](https://github.com/snu-quiqcl/qiwis/assets/76851886/f6e30c60-5259-4289-ba2e-aaa5e399b1a7)
