### PR TITLE
Support for frame title

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -25,5 +25,5 @@ jobs:
         sudo apt-get install python3-pyqt5
     - name: Unittest the code with coverage
       run: |
-        xvfb-run `which coverage` run --source=qiwis -m unittest discover
+        xvfb-run `which coverage` run --source=qiwis -m unittest discover -b
         xvfb-run `which coverage` report

--- a/examples/datacalc.py
+++ b/examples/datacalc.py
@@ -79,9 +79,9 @@ class DataCalcApp(BaseApp):
             dbBox.currentIndexChanged.connect(functools.partial(self.setDB, dbName))
         self.viewerFrame.calculateButton.clicked.connect(self.calculateSum)
 
-    def frames(self) -> Tuple[ViewerFrame]:
+    def frames(self) -> Tuple[Tuple[str, ViewerFrame]]:
         """Overridden."""
-        return (self.viewerFrame,)
+        return (("database calculator", self.viewerFrame),)
 
     def updateDB(self, content: dict):
         """Updates the database list using the transferred message.

--- a/examples/dbmgr.py
+++ b/examples/dbmgr.py
@@ -112,9 +112,9 @@ class DBMgrApp(BaseApp):
         self.managerFrame.addButton.clicked.connect(self.addDB)
         self.managerFrame.openCloseDatacalcButton.clicked.connect(self.openCloseDatacalc)
 
-    def frames(self) -> Tuple[ManagerFrame]:
+    def frames(self) -> Tuple[Tuple[str, ManagerFrame]]:
         """Overridden."""
-        return (self.managerFrame,)
+        return (("database manager", self.managerFrame),)
 
     def sendDB(self, isAdded: bool, name: str):
         """Emits a broadcastRequested signal with the database list and a logging message.

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -168,9 +168,9 @@ class LoggerApp(BaseApp):
             self.handler.setLevel(levels[levelText])
             logging.getLogger().setLevel(levels[levelText])
 
-    def frames(self) -> Tuple[LoggerFrame]:
+    def frames(self) -> Tuple[Tuple[str, LoggerFrame]]:
         """Overridden."""
-        return (self.loggerFrame,)
+        return (("logger", self.loggerFrame),)
 
     @pyqtSlot(str)
     def addLog(self, content: str):

--- a/examples/numgen.py
+++ b/examples/numgen.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Tuple, Union
 from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import QWidget, QComboBox, QPushButton, QLabel, QVBoxLayout
 
-from qiwis import BaseApp, FI
+from qiwis import BaseApp
 from examples.backend import generate, write
 
 logger = logging.getLogger(__name__)
@@ -89,7 +89,7 @@ class NumGenApp(BaseApp):
         self.generatorFrame.dbBox.currentIndexChanged.connect(self.setDB)
         self.generatorFrame.generateButton.clicked.connect(self.generateNumber)
 
-    def frames(self) -> Tuple[FI[Union[GeneratorFrame, ViewerFrame]], ...]:
+    def frames(self) -> Tuple[Tuple[str, Union[GeneratorFrame, ViewerFrame]], ...]:
         """Overridden.
         
         Once a number is generated, returns both frames.

--- a/examples/numgen.py
+++ b/examples/numgen.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Tuple, Union
 from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import QWidget, QComboBox, QPushButton, QLabel, QVBoxLayout
 
-from qiwis import BaseApp
+from qiwis import BaseApp, FI
 from examples.backend import generate, write
 
 logger = logging.getLogger(__name__)
@@ -89,15 +89,15 @@ class NumGenApp(BaseApp):
         self.generatorFrame.dbBox.currentIndexChanged.connect(self.setDB)
         self.generatorFrame.generateButton.clicked.connect(self.generateNumber)
 
-    def frames(self) -> Union[Tuple[GeneratorFrame, ViewerFrame], Tuple[GeneratorFrame]]:
+    def frames(self) -> Tuple[FI[Union[GeneratorFrame, ViewerFrame]], ...]:
         """Overridden.
         
         Once a number is generated, returns both frames.
         Otherwise, returns only the generator frame.
         """
         if self.isGenerated:
-            return (self.generatorFrame, self.viewerFrame)
-        return (self.generatorFrame,)
+            return (("generator", self.generatorFrame), ("viewer", self.viewerFrame))
+        return (("generator", self.generatorFrame),)
 
     def updateDB(self, content: dict):
         """Updates the database list using the transferred message.

--- a/examples/poller.py
+++ b/examples/poller.py
@@ -81,9 +81,9 @@ class PollerApp(BaseApp):
         self.timer.start(1000 * self.viewerFrame.periodBox.value())
         self.timer.timeout.connect(self.poll)
 
-    def frames(self) -> Tuple[ViewerFrame]:
+    def frames(self) -> Tuple[Tuple[str, ViewerFrame]]:
         """Overridden."""
-        return (self.viewerFrame,)
+        return (("poller", self.viewerFrame),)
 
     def updateDB(self, content: dict):
         """Updates the database list using the transferred message.

--- a/qiwis.py
+++ b/qiwis.py
@@ -569,11 +569,12 @@ class BaseApp(QObject):
         """The global constant namespace."""
         return self._constants
 
-    def frames(self) -> Iterable[QWidget]:
+    def frames(self) -> Iterable[Tuple[str, QWidget]]:
         """Gets frames for which are managed by the App.
 
         Returns:
-            An iterable object of Frame objects for showing.
+            An iterable object with frames info for showing.
+            Each entry is a tuple with frame title and frame object.
         """
         return ()
 

--- a/qiwis.py
+++ b/qiwis.py
@@ -378,7 +378,8 @@ class Qiwis(QObject):
         orgFramesSet = set(orgFrames)
         newFramesSet = set(newFrames)
         for frame in orgFramesSet - newFramesSet:
-            self.removeFrame(name, orgFrames[frame])
+            wrapperWidget = orgFrames[frame]
+            self.removeFrame(name, wrapperWidget)
         for frame in newFramesSet - orgFramesSet:
             title = newFrames[frame]
             self.addFrame(name, title, frame, info)

--- a/qiwis.py
+++ b/qiwis.py
@@ -570,7 +570,7 @@ class BaseApp(QObject):
         return self._constants
 
     def frames(self) -> Iterable[Tuple[str, QWidget]]:
-        """Gets frames for which are managed by the App.
+        """Returns frames info for showing.
 
         Returns:
             An iterable object with frames info for showing.

--- a/qiwis.py
+++ b/qiwis.py
@@ -370,18 +370,18 @@ class Qiwis(QObject):
         """
         app = self._apps[name]
         info = self.appInfos[name]
-        orgFrames = {
+        wrapperWidgets = {
             wrapperWidget.widget(): wrapperWidget
             for wrapperWidget in self._wrapperWidgets[name]
         }
-        newFrames = {frame: title for title, frame in app.frames()}
-        orgFramesSet = set(orgFrames)
-        newFramesSet = set(newFrames)
+        frameTitles = {frame: title for title, frame in app.frames()}
+        orgFramesSet = set(wrapperWidgets)
+        newFramesSet = set(frameTitles)
         for frame in orgFramesSet - newFramesSet:
-            wrapperWidget = orgFrames[frame]
+            wrapperWidget = wrapperWidgets[frame]
             self.removeFrame(name, wrapperWidget)
         for frame in newFramesSet - orgFramesSet:
-            title = newFrames[frame]
+            title = frameTitles[frame]
             self.addFrame(name, title, frame, info)
         logger.info("Updated frames: %d -> %d", len(orgFramesSet), len(newFramesSet))
 

--- a/qiwis.py
+++ b/qiwis.py
@@ -255,7 +255,7 @@ class Qiwis(QObject):
         
         Args:
             name: The app name to which frame is added.
-            titme: The frame title.
+            title: The frame title.
             frame: Frame object to show.
             info: AppInfo object describing the app.
         """

--- a/qiwis.py
+++ b/qiwis.py
@@ -37,6 +37,9 @@ from PyQt5.QtWidgets import (
 )
 
 T = TypeVar("T")
+F = TypeVar("F")  # frame type
+FI = Tuple[str, F]  # frame info type for frames()
+
 JsonType = Union[None, float, bool, str, List["JsonType"], Dict[str, "JsonType"]]
 # Generic MappingProxyType or GenericAlias is introduced in Python 3.9.
 ImmutableJsonType = Union[None, float, bool, str, Tuple["ImmutableJsonType", ...], MappingProxyType]
@@ -341,7 +344,7 @@ class Qiwis(QObject):
         for channelName in info.channel:
             self.subscribe(name, channelName)
         for title, frame in app.frames():
-            self.addFrame(name, frame, info)
+            self.addFrame(name, title, frame, info)
         self._apps[name] = app
         self.appInfos[name] = info
         logger.info("Created an app %s: %s", name, info)
@@ -571,7 +574,7 @@ class BaseApp(QObject):
         """The global constant namespace."""
         return self._constants
 
-    def frames(self) -> Iterable[Tuple[str, QWidget]]:
+    def frames(self) -> Iterable[FI[QWidget]]:
         """Returns frames info for showing.
 
         Returns:

--- a/qiwis.py
+++ b/qiwis.py
@@ -37,9 +37,6 @@ from PyQt5.QtWidgets import (
 )
 
 T = TypeVar("T")
-F = TypeVar("F")  # frame type
-FI = Tuple[str, F]  # frame info type for frames()
-
 JsonType = Union[None, float, bool, str, List["JsonType"], Dict[str, "JsonType"]]
 # Generic MappingProxyType or GenericAlias is introduced in Python 3.9.
 ImmutableJsonType = Union[None, float, bool, str, Tuple["ImmutableJsonType", ...], MappingProxyType]
@@ -574,7 +571,7 @@ class BaseApp(QObject):
         """The global constant namespace."""
         return self._constants
 
-    def frames(self) -> Iterable[FI[QWidget]]:
+    def frames(self) -> Iterable[Tuple[str, QWidget]]:
         """Returns frames info for showing.
 
         Returns:

--- a/qiwis.py
+++ b/qiwis.py
@@ -248,24 +248,25 @@ class Qiwis(QObject):
             self.createApp(name, info)
         logger.info("Loaded %d app(s)", len(appInfos))
 
-    def addFrame(self, name: str, frame: QWidget, info: AppInfo):
+    def addFrame(self, name: str, title: str, frame: QWidget, info: AppInfo):
         """Adds the given frame and wraps it with a wrapper widget.
 
         This is not a qiwiscall because QWidget is not Serializable.
         
         Args:
-            name: A name of app.
-            frame: A frame to show.
-            info: An AppInfo object describing the app.
+            name: The app name to which frame is added.
+            titme: The frame title.
+            frame: Frame object to show.
+            info: AppInfo object describing the app.
         """
         if info.pos == "center":
             wrapperWidget = MdiSubWindow(self.centralWidget)
-            wrapperWidget.setWindowTitle(name)
+            wrapperWidget.setWindowTitle(title)
             wrapperWidget.setWidget(frame)
             wrapperWidget.closed.connect(functools.partial(self.destroyApp, name))
             wrapperWidget.show()
         else:
-            wrapperWidget = QDockWidget(name, self.mainWindow)
+            wrapperWidget = QDockWidget(title, self.mainWindow)
             wrapperWidget.setWidget(frame)
             area = {
                 "left": Qt.LeftDockWidgetArea,
@@ -285,7 +286,7 @@ class Qiwis(QObject):
             if info.pos == "floating":
                 wrapperWidget.setFloating(True)
         self._wrapperWidgets[name].append(wrapperWidget)
-        logger.info("Added a frame to the app %s: %s", name, info)
+        logger.info("Added a frame %s to the app %s: %s", title, name, info)
 
     def removeFrame(self, name: str, wrapperWidget: Union[QMdiSubWindow, QDockWidget]):
         """Removes the frame from the main window.
@@ -339,7 +340,7 @@ class Qiwis(QObject):
         )
         for channelName in info.channel:
             self.subscribe(name, channelName)
-        for frame in app.frames():
+        for title, frame in app.frames():
             self.addFrame(name, frame, info)
         self._apps[name] = app
         self.appInfos[name] = info

--- a/qiwis.py
+++ b/qiwis.py
@@ -261,7 +261,7 @@ class Qiwis(QObject):
         """
         if info.pos == "center":
             wrapperWidget = MdiSubWindow(self.centralWidget)
-            wrapperWidget.setWindowTitle(title)
+            wrapperWidget.setWindowTitle(f"{name} - {title}" if title else name)
             wrapperWidget.setWidget(frame)
             wrapperWidget.closed.connect(functools.partial(self.destroyApp, name))
             wrapperWidget.show()

--- a/qiwis.py
+++ b/qiwis.py
@@ -256,8 +256,8 @@ class Qiwis(QObject):
         Args:
             name: The app name to which frame is added.
             title: The frame title.
-            frame: Frame object to show.
-            info: AppInfo object describing the app.
+            frame: The frame widget to show.
+            info: The AppInfo object describing the app.
         """
         if info.pos == "center":
             wrapperWidget = MdiSubWindow(self.centralWidget)

--- a/qiwis.py
+++ b/qiwis.py
@@ -363,10 +363,10 @@ class Qiwis(QObject):
         logger.info("Destroyed the app %s", name)
 
     def updateFrames(self, name: str):
-        """Updates the frames of an app.
+        """Updates frames of the given app.
         
         Args:
-            name: A name of the app to update its frames.
+            name: The app name to update its frames.
         """
         app = self._apps[name]
         info = self.appInfos[name]
@@ -374,13 +374,14 @@ class Qiwis(QObject):
             wrapperWidget.widget(): wrapperWidget
             for wrapperWidget in self._wrapperWidgets[name]
         }
-        newFrames = app.frames()
+        newFrames = {frame: title for title, frame in app.frames()}
         orgFramesSet = set(orgFrames)
         newFramesSet = set(newFrames)
         for frame in orgFramesSet - newFramesSet:
             self.removeFrame(name, orgFrames[frame])
         for frame in newFramesSet - orgFramesSet:
-            self.addFrame(name, frame, info)
+            title = newFrames[frame]
+            self.addFrame(name, title, frame, info)
         logger.info("Updated frames: %d -> %d", len(orgFramesSet), len(newFramesSet))
 
     def channelNames(self) -> Tuple[str]:

--- a/test.py
+++ b/test.py
@@ -9,7 +9,7 @@ import json
 import unittest
 from unittest import mock
 from types import MappingProxyType
-from typing import Any, Optional, Mapping, Iterable
+from typing import Any, Optional, Mapping, Iterable, Set
 
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QApplication, QMessageBox, QWidget
@@ -67,7 +67,7 @@ class QiwisTestWithApps(unittest.TestCase):
         for appInfo in APP_INFOS.values():
             app = mock.MagicMock()
             app.cls = appInfo.cls
-            app.frames.return_value = (QWidget(),)
+            app.frames.return_value = (("title", QWidget()),)
             cls = mock.MagicMock(return_value=app)
             setattr(self.mocked_import_module.return_value, appInfo.cls, cls)
         self.channels = set()
@@ -94,7 +94,7 @@ class QiwisTestWithApps(unittest.TestCase):
     def test_create_app(self):
         app = mock.MagicMock()
         app.cls = "cls3"
-        app.frames.return_value = (QWidget(),)
+        app.frames.return_value = (("title", QWidget()),)
         cls = mock.MagicMock(return_value=app)
         setattr(self.mocked_import_module.return_value, "cls3", cls)
         self.qiwis.createApp(
@@ -111,7 +111,7 @@ class QiwisTestWithApps(unittest.TestCase):
         orgApp = self.qiwis._apps["app2"]
         app = mock.MagicMock()
         app.cls = "cls2"
-        app.frames.return_value = (QWidget(),)
+        app.frames.return_value = (("title", QWidget()),)
         cls = mock.MagicMock(return_value=app)
         setattr(self.mocked_import_module.return_value, "cls2", cls)
         appInfo = qiwis.AppInfo(module="module2", cls="cls2")
@@ -135,20 +135,24 @@ class QiwisTestWithApps(unittest.TestCase):
 
     def test_update_frames_inclusive(self):
         """Tests for the case where a new frame is added in the return of frames()."""
-        orgFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
+        orgFramesSet = {wrapperWidget.widget()
+                        for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = orgFramesSet | {QWidget()}
-        self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
+        self.qiwis._apps["app1"].frames.return_value = (("title", frame) for frame in newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
+        finalFramesSet = {wrapperWidget.widget()
+                          for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
         self.assertEqual(finalFramesSet, newFramesSet)
 
     def test_update_frames_exclusive(self):
         """Tests for the case where a new frame replaced the return of frames()."""
-        orgFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
+        orgFramesSet = {wrapperWidget.widget()
+                        for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = {QWidget()}
-        self.qiwis._apps["app1"].frames.return_value = tuple(newFramesSet)
+        self.qiwis._apps["app1"].frames.return_value = (("title", frame) for frame in newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
+        finalFramesSet = {wrapperWidget.widget()
+                          for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
         self.assertFalse(finalFramesSet & orgFramesSet)
         self.assertEqual(finalFramesSet, newFramesSet)
 

--- a/test.py
+++ b/test.py
@@ -135,24 +135,20 @@ class QiwisTestWithApps(unittest.TestCase):
 
     def test_update_frames_inclusive(self):
         """Tests for the case where a new frame is added in the return of frames()."""
-        orgFramesSet = {wrapperWidget.widget()
-                        for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
+        orgFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = orgFramesSet | {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = (("title", frame) for frame in newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {wrapperWidget.widget()
-                          for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
+        finalFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         self.assertEqual(finalFramesSet, newFramesSet)
 
     def test_update_frames_exclusive(self):
         """Tests for the case where a new frame replaced the return of frames()."""
-        orgFramesSet = {wrapperWidget.widget()
-                        for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
+        orgFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = {QWidget()}
         self.qiwis._apps["app1"].frames.return_value = (("title", frame) for frame in newFramesSet)
         self.qiwis.updateFrames("app1")
-        finalFramesSet = {wrapperWidget.widget()
-                          for wrapperWidget in self.qiwis._wrapperWidgets["app1"]}
+        finalFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         self.assertFalse(finalFramesSet & orgFramesSet)
         self.assertEqual(finalFramesSet, newFramesSet)
 

--- a/test.py
+++ b/test.py
@@ -137,7 +137,8 @@ class QiwisTestWithApps(unittest.TestCase):
         """Tests for the case where a new frame is added in the return of frames()."""
         orgFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = orgFramesSet | {QWidget()}
-        self.qiwis._apps["app1"].frames.return_value = (("title", frame) for frame in newFramesSet)
+        self.qiwis._apps["app1"].frames.return_value = tuple(("title", frame)
+                                                             for frame in newFramesSet)
         self.qiwis.updateFrames("app1")
         finalFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         self.assertEqual(finalFramesSet, newFramesSet)
@@ -146,7 +147,8 @@ class QiwisTestWithApps(unittest.TestCase):
         """Tests for the case where a new frame replaced the return of frames()."""
         orgFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         newFramesSet = {QWidget()}
-        self.qiwis._apps["app1"].frames.return_value = (("title", frame) for frame in newFramesSet)
+        self.qiwis._apps["app1"].frames.return_value = tuple(("title", frame)
+                                                             for frame in newFramesSet)
         self.qiwis.updateFrames("app1")
         finalFramesSet = {wrapper.widget() for wrapper in self.qiwis._wrapperWidgets["app1"]}
         self.assertFalse(finalFramesSet & orgFramesSet)

--- a/test.py
+++ b/test.py
@@ -9,7 +9,7 @@ import json
 import unittest
 from unittest import mock
 from types import MappingProxyType
-from typing import Any, Optional, Mapping, Iterable, Set
+from typing import Any, Optional, Mapping, Iterable
 
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QApplication, QMessageBox, QWidget


### PR DESCRIPTION
This closes #231.

Now, a frame title is supported and it can be set in `frames()` of each app.

To meet the modified `frames()`, I updated `Qiwis` class and several unit tests.