### PR TITLE
Add `trust` opt in app info to bypass checking permission

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -5,6 +5,7 @@
             "cls": "NumGenApp",
             "pos": "left",
             "channel": ["db"],
+            "trust": true,
             "args": {
                 "table": "number"
             }

--- a/qiwis.py
+++ b/qiwis.py
@@ -514,8 +514,7 @@ class Qiwis(QObject):
         In fact the partial method will be connected using functools.partial().
 
         Args:
-            sender: See _handleQiwiscall().
-            msg: See _handleQiwiscall().
+            See _handleQiwiscall().
         """
         try:
             value = self._handleQiwiscall(sender, msg)

--- a/qiwis.py
+++ b/qiwis.py
@@ -71,6 +71,7 @@ class AppInfo(Serializable):
           In the other cases, the frame is wrapped by QDockWidget and
             its position follows Qt.DockWidgetArea.
         channel: The list of channels which the app subscribes to.
+        trust: If True, all qiwiscalls requested by the app are not asked for permission.
         args: The dictionary for the keyword arguments of the app class constructor.
           It should exclude the name and parent arguments.
           None for initializing the app with default values,
@@ -81,6 +82,7 @@ class AppInfo(Serializable):
     path: str = "."
     pos: str = ""
     channel: Iterable[str] = ()
+    trust: bool = False
     args: Optional[Mapping[str, Any]] = None
 
 

--- a/qiwis.py
+++ b/qiwis.py
@@ -496,16 +496,18 @@ class Qiwis(QObject):
             raise ValueError("Only public method calls are allowed.")
         call = getattr(self, info.call)
         args = self._parseArgs(call, info.args)
-        reply = QMessageBox.warning(
-            None,
-            "qiwiscall",
-            f"The app {sender} requests for a qiwiscall {info.call} with {args}.",
-            QMessageBox.Ok | QMessageBox.Cancel,
-            QMessageBox.Cancel,
-        )
-        if reply == QMessageBox.Ok:
-            return call(**args)
-        raise RuntimeError("The user rejected the request.")
+        trust = self.appInfos[sender].trust
+        if not trust:
+            reply = QMessageBox.warning(
+                None,
+                "qiwiscall",
+                f"The app {sender} requests for a qiwiscall {info.call} with {args}.",
+                QMessageBox.Ok | QMessageBox.Cancel,
+                QMessageBox.Cancel,
+            )
+            if reply != QMessageBox.Ok:
+                raise RuntimeError("The user rejected the request.")
+        return call(**args)
 
     def _qiwiscall(self, sender: str, msg: str):
         """Will be connected to the qiwiscallRequested signal.

--- a/test.py
+++ b/test.py
@@ -47,10 +47,10 @@ APP_DICTS = {
 }
 
 APP_JSONS = {
-    "app1": ('{"module": "module1", "cls": "cls1", "path": "path1", '
-             '"pos": "left", "channel": ["ch1", "ch2"], "args": {"arg1": "value1"}}'),
-    "app2": ('{"module": "module2", "cls": "cls2", "path": ".", '
-             '"pos": "", "channel": [], "args": null}'),
+    "app1": ('{"module": "module1", "cls": "cls1", "path": "path1", "pos": "left", '
+             '"channel": ["ch1", "ch2"], "trust": false, "args": {"arg1": "value1"}}'),
+    "app2": ('{"module": "module2", "cls": "cls2", "path": ".", "pos": "", '
+             '"channel": [], "trust": false, "args": null}'),
     "app2_default": '{"module": "module2", "cls": "cls2"}'
 }
 

--- a/test.py
+++ b/test.py
@@ -309,7 +309,8 @@ class HandleQiwiscallTest(unittest.TestCase):
         msg = json.dumps({"call": "callForTest", "args": args})
         mocked_loads.return_value = info
         mocked_warning.return_value = QMessageBox.Ok
-        with mock.patch.multiple(self.qiwis, create=True,
+        app_infos = {"sender": qiwis.AppInfo(module="module", cls="cls")}
+        with mock.patch.multiple(self.qiwis, create=True, appInfos=app_infos,
                                  callForTest=mock.DEFAULT, _parseArgs=mock.DEFAULT):
             self.qiwis._parseArgs.return_value = args
             self.qiwis._handleQiwiscall(sender="sender", msg=msg)
@@ -324,7 +325,8 @@ class HandleQiwiscallTest(unittest.TestCase):
         msg = json.dumps({"call": "callForTest", "args": args})
         mocked_loads.return_value = info
         mocked_warning.return_value = QMessageBox.Cancel
-        with mock.patch.multiple(self.qiwis, create=True,
+        app_infos = {"sender": qiwis.AppInfo(module="module", cls="cls")}
+        with mock.patch.multiple(self.qiwis, create=True, appInfos=app_infos,
                                  callForTest=mock.DEFAULT, _parseArgs=mock.DEFAULT):
             self.qiwis._parseArgs.return_value = args
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
This closes #237.

I set `trust` option of `numgen` app to `True`, so the qiwiscall requested by it are bypassed to check permission.