### PR TITLE
Show at maximum size when opened

### DIFF
--- a/qiwis.py
+++ b/qiwis.py
@@ -202,11 +202,13 @@ class Qiwis(QObject):
         self,
         appInfos: Optional[Mapping[str, AppInfo]] = None,
         constants: Optional[Tuple] = None,
+        isMaximized: bool = False,
         parent: Optional[QObject] = None):
         """
         Args:
             appInfos: See Qiwis.load(). None or an empty dictionary for loading no apps.
             constants: The global constant namespace. See set_global_constant_namespace().
+            isMaximized: See "-m" option in _get_argparser().
             parent: A parent object.
         """
         super().__init__(parent=parent)
@@ -226,7 +228,10 @@ class Qiwis(QObject):
         appInfos = appInfos if appInfos else {}
         self.setIcon(icon_path)
         self.load(appInfos)
-        self.mainWindow.showMaximized()
+        if isMaximized:
+            self.mainWindow.showMaximized()
+        else:
+            self.mainWindow.show()
 
     def setIcon(self, icon_path: Optional[str]):
         """Sets the icon image.
@@ -845,7 +850,7 @@ def main():
     # start GUI
     qapp = QApplication(sys.argv)
     constants_ = set_global_constant_namespace(constants)
-    _qiwis = Qiwis(app_infos, constants_)
+    _qiwis = Qiwis(app_infos, constants_, args.is_maximized)
     logger.info("Now the QApplication starts")
     qapp.exec_()
 

--- a/qiwis.py
+++ b/qiwis.py
@@ -778,7 +778,7 @@ def _get_argparser() -> argparse.ArgumentParser:
         description="QuIqcl Widget Integration Software"
     )
     parser.add_argument(
-        "-m", "--maximize", dest="is_maximized", default=False,
+        "-m", "--maximize", dest="is_maximized", action="store_true",
         help="Whether the initial screen is maximized or not"
     )
     parser.add_argument(

--- a/qiwis.py
+++ b/qiwis.py
@@ -763,6 +763,7 @@ def _add_to_path(path: str):
 def _get_argparser() -> argparse.ArgumentParser:
     """Parses command line arguments.
 
+    -m, --maximize: Maximizes the initial screen size.
     -c, --config: A path of set-up file.
 
     Returns:
@@ -770,6 +771,10 @@ def _get_argparser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(
         description="QuIqcl Widget Integration Software"
+    )
+    parser.add_argument(
+        "-m", "--maximize", dest="is_maximized", default=False,
+        help="Whether the initial screen is maximized or not"
     )
     parser.add_argument(
         "-c", "--config", dest="config_path", default="./config.json",

--- a/qiwis.py
+++ b/qiwis.py
@@ -226,7 +226,7 @@ class Qiwis(QObject):
         appInfos = appInfos if appInfos else {}
         self.setIcon(icon_path)
         self.load(appInfos)
-        self.mainWindow.show()
+        self.mainWindow.showMaximized()
 
     def setIcon(self, icon_path: Optional[str]):
         """Sets the icon image.


### PR DESCRIPTION
_(Updated)_

Now, we can open a qiwis application at maximum or default size through "-m" option.

The screenshot below is when using "-m" option, i.e., running `python -m qiwis -m -c examples/config.json`.

![image](https://github.com/snu-quiqcl/qiwis/assets/76851886/a955fbf1-efc8-4b96-81d5-c5fa503f734e)

This closes #246.